### PR TITLE
Update instruction on running unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Clone this repo to your local machine using CLI or any git softwares
 git clone https://github.com/offthegrid-mike/limiter-module.git
 ```
 
-cd to repo foler and install required dependencies if needed
+cd to repo folder and install required dependencies if needed
 ```
 npm install
 ```
 
-Install necessary module for unit testing
+Run unit tests
 ```
-npm install mocha
+npm run test
 ```
 
 # Run application

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
`mocha` is installed during `npm install`, no need to install it again. Perhaps we should update the test script to let it run the `mocha` tests when `nom run test`